### PR TITLE
refactor/split web socket protocol

### DIFF
--- a/Frontend/src/components/TableEditor.tsx
+++ b/Frontend/src/components/TableEditor.tsx
@@ -22,8 +22,8 @@ import type {
   DiffDelete,
   DiffNone,
   StrDiff,
-  MutateMessage,
-  Message
+  ServerCellMutateMessage,
+  ServerMessage
 } from '@/types/WebSocketProtocol';
 
 const diffStrings = (olds: string, news: string): DiffInsert | DiffReplace | DiffDelete | DiffNone => {
@@ -101,7 +101,7 @@ export const TableEditor: React.FC<TableEditorProps> = (props: TableEditorProps)
 
   console.log('Client ID:', clientId);
 
-  const mutateCell = (msg: MutateMessage): void => {
+  const mutateCell = (msg: ServerCellMutateMessage): void => {
     const [row, col] = msg.cell;
 
     setTable((oldTable) => {
@@ -149,7 +149,8 @@ export const TableEditor: React.FC<TableEditorProps> = (props: TableEditorProps)
   const handleMessage = (event: any): void => {
     try {
       const clientId = clientIdRef.current;
-      const msg = JSON.parse(event.data) as Message;
+      const msg = JSON.parse(event.data) as ServerMessage;
+
       console.log('Received:', msg);
       if (msg.type === 'init') {
         if (Array.isArray(msg.table)) {

--- a/Frontend/src/components/TableEditor.tsx
+++ b/Frontend/src/components/TableEditor.tsx
@@ -17,16 +17,15 @@ import type TableProps from '@/types/TableProps';
 
 import type {
   TableCellData,
-  DiffInsert,
-  DiffReplace,
-  DiffDelete,
-  DiffNone,
   StrDiff,
   ServerCellMutateMessage,
-  ServerMessage
+  ServerMessage,
+  ClientStringMutateMessage,
+  ClientMessageInsertRows,
+  ClientMessageInsertCols
 } from '@/types/WebSocketProtocol';
 
-const diffStrings = (olds: string, news: string): DiffInsert | DiffReplace | DiffDelete | DiffNone => {
+const diffStrings = (olds: string, news: string): StrDiff => {
   if (olds === news) return { type: "none" };
 
   // Find common prefix
@@ -159,7 +158,6 @@ export const TableEditor: React.FC<TableEditorProps> = (props: TableEditorProps)
           setTable(() => msg.table);
         }
       } else if (msg.type === 'insert_rows') {
-        // TODO: row insertion logic here
         const { insertion_index: insertionIndex, num_rows: numRows} =  msg;
 
         // Insert rows with blank text
@@ -175,7 +173,6 @@ export const TableEditor: React.FC<TableEditorProps> = (props: TableEditorProps)
           ];
         });
       } else if (msg.type === 'insert_cols') {
-        // TODO: row insertion logic here
         const { insertion_index: insertionIndex, num_cols: numCols } =  msg;
 
         // Insert cols with blank text
@@ -209,7 +206,9 @@ export const TableEditor: React.FC<TableEditorProps> = (props: TableEditorProps)
       const diff = diffStrings(text, newText);
 
       if (socket && diff.type !== 'none') {
-        const message = { client_id: 0, cell: [row, col], ...diff};
+        const message: ClientStringMutateMessage = ({
+          cell: [row, col], ...diff
+        });
         socket.send(JSON.stringify(message));
         setText(row, col, newText);
       }
@@ -228,25 +227,27 @@ export const TableEditor: React.FC<TableEditorProps> = (props: TableEditorProps)
 
   const makeInsertRow = (iRow: number) => () => {
     if (socket) {
-      console.log(`Inserting row at ${iRow}`);
-      socket.send(JSON.stringify({
+      const insertRowsMsg : ClientMessageInsertRows = ({
         type: "insert_rows",
-        client_id: 0,
         insertion_index: iRow,
         num_rows: 1
-      }));
+      });
+
+      console.log(`Inserting row at ${iRow}`);
+      socket.send(JSON.stringify(insertRowsMsg));
     }
   };
 
   const makeInsertCol = (iCol: number) => () => {
     if (socket) {
-      console.log(`Inserting col at ${iCol}`);
-      socket.send(JSON.stringify({
+      const insertColsMsg : ClientMessageInsertCols = ({
         type: "insert_cols",
-        client_id: 0,
         insertion_index: iCol,
         num_cols: 1
-      }));
+      });
+
+      console.log(`Inserting col at ${iCol}`);
+      socket.send(JSON.stringify(insertColsMsg));
     }
   };
 

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -1,6 +1,9 @@
-
-
+// === WebSocketProtocol =======================================================
+//
 // Define the types for incoming and outgoing messages
+//
+// =============================================================================
+
 export interface TableCellData {
   text: string;
   owner_id?: number;
@@ -31,52 +34,92 @@ export interface DiffNone {
 
 export type StrDiff = DiffInsert | DiffReplace | DiffDelete;
 
-export interface MessageInit {
+// === Server-to-Client messages ===============================================
+export interface ServerMessageInit {
   type: "init";
   client_id: number;
   table: TableCellData[][];
 };
 
-export interface MessageInsert extends DiffInsert {
+export interface ServerMessageInsert extends DiffInsert {
   client_id: number;
   cell: [number, number];
 };
 
-export interface MessageDelete extends DiffDelete {
+export interface ServerMessageDelete extends DiffDelete {
   client_id: number;
   cell: [number, number];
 };
 
-export interface MessageReplace extends DiffReplace {
+export interface ServerMessageReplace extends DiffReplace {
   client_id: number;
   cell: [number, number];
 };
 
-export interface MessageInsertRows {
+export interface ServerMessageInsertRows {
   type: "insert_rows";
   client_id: number;
   insertion_index: number;
   num_rows: number;
 }
 
-export interface MessageInsertCols {
+export interface ServerMessageInsertCols {
   type: "insert_cols";
   client_id: number;
   insertion_index: number;
   num_cols: number;
 }
 
-export interface MessageAcquireLock {
+export interface ServerMessageAcquireLock {
   type: "acquire_lock";
   client_id: number;
   cell: [number, number];
 };
 
-export interface MessageReleaseLock {
+export interface ServerMessageReleaseLock {
   type: "release_lock";
   cell: [number, number];
 };
 
-export type ClientMutateMessage = MessageInsert | MessageDelete | MessageReplace | MessageAcquireLock;
-export type MutateMessage = ClientMutateMessage | MessageReleaseLock;
-export type Message = MessageInit | MutateMessage | MessageInsertRows | MessageInsertCols;
+export type ServerStringMutateMessage = ServerMessageInsert | ServerMessageDelete | ServerMessageReplace | ServerMessageAcquireLock;
+export type ServerCellMutateMessage = ServerStringMutateMessage | ServerMessageReleaseLock;
+export type ServerMessage = ServerMessageInit | ServerCellMutateMessage | ServerMessageInsertRows | ServerMessageInsertCols;
+
+// === Client-to-Server messages ===============================================
+export interface ClientMessageInsert extends DiffInsert {
+  cell: [number, number];
+};
+
+export interface ClientMessageDelete extends DiffDelete {
+  cell: [number, number];
+};
+
+export interface ClientMessageReplace extends DiffReplace {
+  cell: [number, number];
+};
+
+export interface ClientMessageInsertRows {
+  type: "insert_rows";
+  insertion_index: number;
+  num_rows: number;
+}
+
+export interface ClientMessageInsertCols {
+  type: "insert_cols";
+  insertion_index: number;
+  num_cols: number;
+}
+
+export interface ClientMessageAcquireLock {
+  type: "acquire_lock";
+  cell: [number, number];
+};
+
+export interface ClientMessageReleaseLock {
+  type: "release_lock";
+  cell: [number, number];
+};
+
+export type ClientStringMutateMessage = ClientMessageInsert | ClientMessageDelete | ClientMessageReplace | ClientMessageAcquireLock;
+export type ClientCellMutateMessage = ClientStringMutateMessage | ClientMessageReleaseLock;
+export type ClientMessage = ClientCellMutateMessage | ClientMessageInsertRows | ClientMessageInsertCols;

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -110,16 +110,6 @@ export interface ClientMessageInsertCols {
   num_cols: number;
 }
 
-export interface ClientMessageAcquireLock {
-  type: "acquire_lock";
-  cell: [number, number];
-};
-
-export interface ClientMessageReleaseLock {
-  type: "release_lock";
-  cell: [number, number];
-};
-
-export type ClientStringMutateMessage = ClientMessageInsert | ClientMessageDelete | ClientMessageReplace | ClientMessageAcquireLock;
-export type ClientCellMutateMessage = ClientStringMutateMessage | ClientMessageReleaseLock;
+export type ClientStringMutateMessage = ClientMessageInsert | ClientMessageDelete | ClientMessageReplace;
+export type ClientCellMutateMessage = ClientStringMutateMessage;
 export type ClientMessage = ClientCellMutateMessage | ClientMessageInsertRows | ClientMessageInsertCols;

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -32,7 +32,7 @@ export interface DiffNone {
   type: "none";
 };
 
-export type StrDiff = DiffInsert | DiffReplace | DiffDelete;
+export type StrDiff = DiffInsert | DiffReplace | DiffDelete | DiffNone;
 
 // === Server-to-Client messages ===============================================
 export interface ServerMessageInit {


### PR DESCRIPTION
- Split client-side web socket definitions into server-to-client and client-to-server messages in frontend
- Changed types of web socket messages to reflect split server-to-client and client-to-server messages in TableEditor.tsx
- Added DiffNone to StrDiff type in WebSocketProtocol.ts
- Added client-server message type checks to TableEditor.tsx
- Removed acquire and release lock messages from Client messages in WebSocketProtocol.ts
- Split web socket protocol into client and server message enums in WebSocketServer
